### PR TITLE
Linux / Eclips / ADT + bugfix (MacOS too???)

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -113,7 +113,7 @@ Device: select device from previous step (OUYA_720)
 Target: Android 4.1.2 - API Level 16
 CPU/ABI: Intel Atom (x86)
 Kayboard: Hardware keyboard present (?)
-Skin: - (?)
+Skin: Display a skin with hardware control (?)
 No cameras
 Memory Options: RAM: 1024 VM Heap: 32 (?)
 Internal Storage: 200 (?) MiB


### PR DESCRIPTION
BUGFIX: put sdk binaries before native in path if this is not done you never know what has been run
(as an example my native sqlite3)
