### PR TITLE
Remove windows adb command & reference to unused libs

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -98,7 +98,6 @@ Before continuing, make sure your OUYA is powered and **not connected to your co
         adb kill-server  
         echo 0x2836 >> "%USERPROFILE%\.android\adb_usb.ini"  
         adb start-server  
-        adb devices  
 
 7. Open the Device Manager (Right-click My Computer->Properties->Device Manager)
 
@@ -138,7 +137,7 @@ This will create a working Eclipse project. If your OUYA console is connected, y
 
 Use the Android API Level 16 (Android 4.1 "Jelly Bean") when developing for the OUYA Console.
 
-In order to use the OUYA API you will need to include `ouya-sdk.jar` in your project libraries, as well as `guava-r09.jar` and `commons-lang-2.6.jar`. These can be found in the `libs` directory.
+In order to use the OUYA API you will need to include `ouya-sdk.jar` in your project libraries.  This can be found in the `libs` directory.
 
 For information on the API commands available, please consult the OUYA API reference documentation.
 


### PR DESCRIPTION
Removed a useless 'adb devices' command in the windows instructions.

Also removed the referencing of 2 libs that are not used in any examples or in the OUYA jar file.  These libs have always been included with the OUYA ODK, along with a few others, but they are not required by the OUYA ODK Jar nor are they used in any examples.  

There's a good chance they don't even need to be part of the ODK.

Output from JarAnalyzer below:

``` xml
<Jar name="ouya-sdk.jar">
    <Summary>
        <Statistics>
            <ClassCount>138</ClassCount>
            <AbstractClassCount>36</AbstractClassCount>
            <PackageCount>6</PackageCount>
        </Statistics>

        <Metrics>
            <Abstractness>0.26</Abstractness>
            <Efferent>0</Efferent>
            <Afferent>0</Afferent>
            <Instability>-1.0</Instability>
            <Distance>-1.0</Distance>
        </Metrics>

        <Packages>
            <Package>tv.ouya.console.api</Package>
            <Package>tv.ouya.console.api.store</Package>
            <Package>tv.ouya.console.iap.api</Package>
            <Package>tv.ouya.console.internal</Package>
            <Package>tv.ouya.console.internal.util</Package>
            <Package>tv.ouya.console.util</Package>
        </Packages>

        <OutgoingDependencies>
        </OutgoingDependencies>

        <IncomingDependencies>
        </IncomingDependencies>

        <Cycles>
        </Cycles>

        <UnresolvedDependencies>
            <Package>android.os</Package>
            <Package>org.json</Package>
            <Package>android.util</Package>
            <Package>android.content</Package>
            <Package>android.app</Package>
            <Package>android.accounts</Package>
            <Package>android.view</Package>
            <Package>android.net</Package>
            <Package>android.database</Package>
            <Package>android.content.pm</Package>
        </UnresolvedDependencies>
    </Summary>

</Jar>
```
