### PR TITLE
tell about ODK 1.0.5

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -274,6 +274,8 @@ In order to begin developing software before having access to an OUYA console, y
 
 ##### Software
 
+**Note**: You need to use ODK 1.0.5, since all following OUYA launcher versions require an OOBE package that is not available for download.
+
 The OUYA console hardware already includes the OUYA launcher, but when using an emulator or Android tablet, you will need to install the launcher manually. This file is included in the OUYA ODK package.
 
 To install the launcher, run:


### PR DESCRIPTION
ODK 1.0.5 is the last one that can be used, since the required OOBE isn't available anywhere to download.
